### PR TITLE
Added qt5.graphicaleffects to flake.nix build inputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
           pipewire.dev
           qt5.full
           qt5.wrapQtAppsHook
+          qt5.qtgraphicaleffects
           # Package building tools
           nfpm
           gnumake


### PR DESCRIPTION
I was getting an error as described in #10, where my system could not resolve QtGraphicalEffects. I simply added this to the build inputs of the flake. This happened to me on a nearly fresh install of Omarchy, so I assume others may have this issue in the future.